### PR TITLE
Added a Mac/Linux setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ All runnable files...
 ...can and should be run through CMD with proper arguments. If you struggle with a certain one, try calling --help or
 read the docstring of the script.
 
-For a smooth performance, make sure that the root of the repository is the working directory when running any script
+For smooth performance, make sure that the root of the repository is the working directory when running any script
 and use absolute paths as the arguments.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Comment-Quality
 Install all modules required with 'pip install -r requirements.txt' and install srcML to your PATH. Tested and developed on Windows and Python 3.8
 
+If using Mac or Linux, run the setup.sh script to port the project over and handle all requirements. This will allow you to work with main.py right away, to generate an output.json file from a downloaded test project. 
+
 All runnable files...
 - predictor
 - trainer
@@ -14,3 +16,4 @@ read the docstring of the script.
 
 For smooth performance, make sure that the root of the repository is the working directory when running any script
 and use absolute paths as the arguments.
+

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,27 @@
+# Coality configuration for Mac/Linux
+MODELS="models/"
+OUTPUTS="outputs/"
+OUTPUT_FILE="outputs/example_output.json"
+SRC_ML="http://131.123.42.38/lmcrs/v1.0.0/srcml_1.0.0-1_ubuntu20.04.deb"
+PROJECT_PATH=$(pwd)
+mkdir $MODELS
+mkdir $OUTPUTS
+touch $OUTPUT_FILE
+echo "Created the following:"
+realpath -e $MODELS && realpath -e $OUTPUTS && realpath -e $OUTPUT_FILE
+
+# Next add project to path, takes first argument
+export PYTHONPATH="${PYTHONPATH}:/$PROJECT_PATH"
+
+# Necessary installations
+pip install -r requirements.txt
+python3 -m nltk.downloader stopwords
+python3 -m nltk.downloader punkt
+wget $SRC_ML
+sudo dpkg -i srcml_1.0.0-1_ubuntu20.04.deb
+
+# Make adjustment to comment_rater.py
+sed -i 's/quality_assessment\\data\\abbreviations\.csv/quality_assessment\/data\/abbreviations\.csv/g' quality_assessment/src/comment_rater.py
+
+# Train models
+python3 classification/src/trainer.py classification/data/data_sets_pooja_pascarella/no_pp.txt models/


### PR DESCRIPTION
This script streamlines the process on Linux and allows the user to get setup faster.

To summarise the script:
* Creates the necessary missing directories
* Adds project to "PYTHONPATH" (fixes issue with relative imports)
* Performs downloads and installations (requirements, src_ml, nltk reqs)
* Adjusts comment_rater.py (line 70 uses \ rather than /, which breaks on Linux)
* Uses trainer.py with no_pp.txt and places it into models/

This should allow the user to more quickly run main.py on test projects to generate data. :-)
